### PR TITLE
Allow Media Library collection name to be changed

### DIFF
--- a/config/mailcoach-editor.php
+++ b/config/mailcoach-editor.php
@@ -24,5 +24,12 @@ return [
      * one or more of the disks you've configured in config/filesystems.php.
      */
     'disk_name' => env('MEDIA_DISK', 'public'),
+    
+    /*
+     * The media collection name to use when storing uploaded images from the editor.
+     * You probably don't need to change this,
+     * unless you're already using spatie/laravel-medialibrary in your project.
+     */
+    'collection_name' => env('MEDIA_COLLECTION', 'default'),
 
 ];

--- a/src/Http/Controllers/EditorController.php
+++ b/src/Http/Controllers/EditorController.php
@@ -29,7 +29,7 @@ class EditorController
             $media = $upload
                 ->addMediaFromRequest('file')
                 ->toMediaCollection(
-                    'default',
+                    config('mailcoach-editor.collection_name', 'default'),
                     config('mailcoach-editor.disk_name'),
                 );
         }
@@ -40,7 +40,7 @@ class EditorController
             $media = $upload
                 ->addMediaFromUrl($data['url'])
                 ->toMediaCollection(
-                    'default',
+                    config('mailcoach-editor.collection_name', 'default'),
                     config('mailcoach-editor.disk_name'),
                 );
         }


### PR DESCRIPTION
The Editor plugin for Mailcoach stores all image uploads to the `default` collection.

This is probably fine for most people, but for those of us who are already using `spatie/laravel-medialibrary` in our projects, it would be very helpful to be able to change this.

Thanks!