### PR TITLE
add button support

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -56,7 +56,7 @@
                         class: Table,
                     },
                     code: CodeTool,
-                    //button: Button,
+                    button: AnyButton,
                     inlineCode: {
                         class: InlineCode,
                         shortcut: 'CMD+SHIFT+M',

--- a/src/MailcoachEditorServiceProvider.php
+++ b/src/MailcoachEditorServiceProvider.php
@@ -40,5 +40,6 @@ class MailcoachEditorServiceProvider extends PackageServiceProvider
         Mailcoach::editorScript(Editor::class, 'https://cdn.jsdelivr.net/npm/@editorjs/table@latest');
         Mailcoach::editorScript(Editor::class, 'https://cdn.jsdelivr.net/npm/@editorjs/code@latest');
         Mailcoach::editorScript(Editor::class, 'https://cdn.jsdelivr.net/npm/@editorjs/inline-code@latest');
+        Mailcoach::editorScript(Editor::class, 'https://cdn.jsdelivr.net/npm/editorjs-button@1.0.4');
     }
 }

--- a/src/Renderer/ButtonRenderer.php
+++ b/src/Renderer/ButtonRenderer.php
@@ -18,7 +18,7 @@ class ButtonRenderer extends Renderer
                                 <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                                     <tr>
                                         <td>
-                                            <a href="{$this->data['url']}" class="button button-primary" target="_blank" rel="noopener">{$this->data['text']}</a>
+                                            <a href="{$this->data['link']}" class="button button-primary" target="_blank" rel="noopener">{$this->data['text']}</a>
                                         </td>
                                     </tr>
                                 </table>


### PR DESCRIPTION
A quick patch to add back support for button block. using [AnyButton](https://github.com/kaaaaaaaaaaai/editorjs-button) plugin suggested in [editor.js site](https://github.com/editor-js/awesome-editorjs) .

